### PR TITLE
restclient: Allow passing custom HTTP transport

### DIFF
--- a/restclient.go
+++ b/restclient.go
@@ -13,13 +13,18 @@ import (
 )
 
 type restClient struct {
-	token string
+	token     string
+	transport http.RoundTripper
 }
 
 func newRestClient(token string) *restClient {
 	restClient := new(restClient)
 	restClient.token = token
 	return restClient
+}
+
+func (c *restClient) SetTransport(transport http.RoundTripper) {
+	c.transport = transport
 }
 
 func (c *restClient) Get(url string, result interface{}, expectedStatus int) error {
@@ -53,6 +58,11 @@ func (c *restClient) doRequest(url string, method string, requestBody interface{
 	request.Header.Add("X-Token", c.token)
 	request.Header.Add("Content-Type", "application/json")
 	client := http.Client{}
+
+	if c.transport != nil {
+		client.Transport = c.transport
+	}
+
 	response, err := client.Do(request)
 	if err = isError(response, expectedStatus, err); err != nil {
 		return err


### PR DESCRIPTION
## Why

We'd like to be able to debug communication between the API and client and passing transport is a common way to do it.

## Where we plan to use it

In the 1&1 Terraform provider:
https://www.terraform.io/docs/providers/oneandone/index.html
https://github.com/terraform-providers/terraform-provider-oneandone

## How it can be used

Similarly to how we use the Github SDK in the Github provider:
https://github.com/terraform-providers/terraform-provider-github/blob/master/github/config.go#L31

----

I have intentionally implemented this as a non-breaking change with custom initializer, but I'm open to suggestions on how to make it more aligned with expectations of maintainers/users.