### PR TITLE
Add privatenetworkid server

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -118,6 +118,7 @@ type ServerRequest struct {
 	SSHKey             string   `json:"rsa_key,omitempty"`
 	SSHPassword        *bool    `json:"ssh_password,omitempty"`
 	PublicKey          []string `json:"public_key,omitempty"`
+	PrivateNetworkId   string   `json:"private_network_id,omitempty"`
 }
 
 type ServerAction struct {

--- a/servers.go
+++ b/servers.go
@@ -46,7 +46,7 @@ type ServerHdds struct {
 type Hdd struct {
 	idField
 	Size   int    `json:"size,omitempty"`
-	IsMain bool   `json:"is_main,omitempty"`
+	IsMain bool   `json:"is_main"`
 	Unit   string `json:"unit,omitempty"`
 	ApiPtr
 }


### PR DESCRIPTION
- Added private_network_id to ServerRequest to support assigning a private network on create.
- Removed omitempty from servers.go Hdd as a request for bosh project. 