### PR TITLE
Make apiError public so they can be used outside the package

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,19 +9,19 @@ type errorResponse struct {
 	Message string `json:"message"`
 }
 
-type apiError struct {
+type ApiError struct {
 	httpStatusCode int
 	message        string
 }
 
-func (e apiError) Error() string {
+func (e ApiError) Error() string {
 	return fmt.Sprintf("%d - %s", e.httpStatusCode, e.message)
 }
 
-func (e *apiError) HttpStatusCode() int {
+func (e *ApiError) HttpStatusCode() int {
 	return e.httpStatusCode
 }
 
-func (e *apiError) Message() string {
+func (e *ApiError) Message() string {
 	return e.message
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestCreateError(t *testing.T) {
-	err := apiError{httpStatusCode: 404, message: "Not found"}
+	err := ApiError{httpStatusCode: 404, message: "Not found"}
 
 	if err.HttpStatusCode() != 404 {
 		t.Errorf("Wrong HTTP status code.")

--- a/oneandone.go
+++ b/oneandone.go
@@ -155,7 +155,7 @@ func (api *API) WaitUntilDeleted(in ApiInstance) error {
 	for in != nil {
 		_, err = in.GetState()
 		if err != nil {
-			if apiError, ok := err.(apiError); ok && apiError.httpStatusCode == http.StatusNotFound {
+			if apiError, ok := err.(ApiError); ok && apiError.httpStatusCode == http.StatusNotFound {
 				return nil
 			} else {
 				return err

--- a/restclient.go
+++ b/restclient.go
@@ -110,7 +110,7 @@ func (c *restClient) doRequest(url string, method string, requestBody interface{
 				if err != nil {
 					return err
 				}
-				return apiError{response.StatusCode, fmt.Sprintf("Type: %s; Message: %s", erResp.Type, erResp.Message)}
+				return ApiError{response.StatusCode, fmt.Sprintf("Type: %s; Message: %s", erResp.Type, erResp.Message)}
 			} else {
 				return c.unmarshal(body, result)
 			}

--- a/servers.go
+++ b/servers.go
@@ -11,22 +11,22 @@ type Server struct {
 	ApiPtr
 	Identity
 	descField
-	CreationDate  string           `json:"creation_date,omitempty"`
-	FirstPassword string           `json:"first_password,omitempty"`
-	ServerType    string           `json:"server_type,omitempty"`
-	Ipv6Range     string           `json:"ipv6_range,omitempty"`
-	Hostname      string           `json:"hostname,omitempty"`
-	Datacenter    *Datacenter      `json:"datacenter,omitempty"`
-	Status        *Status          `json:"status,omitempty"`
-	Hardware      *Hardware        `json:"hardware,omitempty"`
-	Image         *Identity        `json:"image,omitempty"`
-	Dvd           *Identity        `json:"dvd,omitempty"`
-	MonPolicy     *Identity        `json:"monitoring_policy,omitempty"`
-	Snapshot      *ServerSnapshot  `json:"snapshot,omitempty"`
-	Ips           []ServerIp       `json:"ips,omitempty"`
-	PrivateNets   []Identity       `json:"private_networks,omitempty"`
-	Alerts        *ServerAlerts    `json:"-"`
-	AlertsRaw     *json.RawMessage `json:"alerts,omitempty"`
+	CreationDate  string                 `json:"creation_date,omitempty"`
+	FirstPassword string                 `json:"first_password,omitempty"`
+	ServerType    string                 `json:"server_type,omitempty"`
+	Ipv6Range     string                 `json:"ipv6_range,omitempty"`
+	Hostname      string                 `json:"hostname,omitempty"`
+	Datacenter    *Datacenter            `json:"datacenter,omitempty"`
+	Status        *Status                `json:"status,omitempty"`
+	Hardware      *Hardware              `json:"hardware,omitempty"`
+	Image         *Identity              `json:"image,omitempty"`
+	Dvd           *Identity              `json:"dvd,omitempty"`
+	MonPolicy     *Identity              `json:"monitoring_policy,omitempty"`
+	Snapshot      *ServerSnapshot        `json:"snapshot,omitempty"`
+	Ips           []ServerIp             `json:"ips,omitempty"`
+	PrivateNets   []ServerPrivateNetwork `json:"private_networks,omitempty"`
+	Alerts        *ServerAlerts          `json:"-"`
+	AlertsRaw     *json.RawMessage       `json:"alerts,omitempty"`
 }
 
 type Hardware struct {
@@ -55,6 +55,11 @@ type serverDeployImage struct {
 	idField
 	Password string    `json:"password,omitempty"`
 	Firewall *Identity `json:"firewall_policy,omitempty"`
+}
+
+type ServerPrivateNetwork struct {
+	Identity
+	ServerIP string `json:"server_ip,omitempty"`
 }
 
 type ServerIp struct {


### PR DESCRIPTION
Without this, users of the client can not type assert returned errors to look at http status codes.
Client methods all return the error interface so this change is backwards compatable