### PR TITLE
Update cloud panel API base URL

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -1,7 +1,7 @@
 package oneandone
 
 // The base url for 1&1 Cloud Server REST API.
-var BaseUrl = "https://cloudpanel-api.1and1.com/v1"
+var BaseUrl = "https://cloudpanel-api.ionos.com/v1"
 
 // Authentication token
 var Token string


### PR DESCRIPTION
To ensure compatibility with ionos domain we should change the base URL in the GO setup file.